### PR TITLE
cmdline: Set kernel loglevel to exclude informational and debug message

### DIFF
--- a/include/configs/imx8mn_var_som.h
+++ b/include/configs/imx8mn_var_som.h
@@ -89,7 +89,7 @@
 	"bsp_script=boot.scr\0" \
 	"image=Image.gz\0" \
 	"img_addr=0x42000000\0" \
-	"console=ttymxc3,115200 earlycon=ec_imx6q,0x30a60000,115200\0" \
+	"console=ttymxc3,115200 earlycon=ec_imx6q,0x30a60000,115200 loglevel=6\0" \
 	"fdt_addr_r=0x43000000\0" \
 	"fdt_addr=0x43000000\0" \
 	"fdt_high=0xffffffffffffffff\0" \


### PR DESCRIPTION
The kernel is relatively noisy on start. Most messages are of the info loglevel:

Reducing the log output also reduces the boottime by 2 seconds while the dmesg buffer after boot still contains all the informations we need.

From the kernel documentation:

```
loglevel=       All Kernel Messages with a loglevel smaller than the
                    console loglevel will be printed to the console. It can
                    also be changed with klogd or other programs. The
                    loglevels are defined as follows:

                    0 (KERN_EMERG)          system is unusable
                    1 (KERN_ALERT)          action must be taken immediately
                    2 (KERN_CRIT)           critical conditions
                    3 (KERN_ERR)            error conditions
                    4 (KERN_WARNING)        warning conditions
                    5 (KERN_NOTICE)         normal but significant condition
                    6 (KERN_INFO)           informational
                    7 (KERN_DEBUG)          debug-level messages
```

We therefore chose to set the loglevel=6 so that only NOTICE and above will be printed.

Signed-off-by: Mimoja <mimoja@meticuloushome.com>