### PR TITLE
 imx8mn/env: Implement boot partition fallbacks

### DIFF
--- a/include/configs/imx8mn_var_som.h
+++ b/include/configs/imx8mn_var_som.h
@@ -122,7 +122,8 @@
 	"optargs=setenv bootargs ${bootargs} ${kernelargs};\0" \
 	"mmcargs=setenv bootargs ${mcore_clk} console=${console} " \
 		"root=/dev/mmcblk${mmcblk}p${mmcpart} rootwait rw ${cma_size} cma_name=linux,cma\0 " \
-	"loadbootscript=load mmc ${mmcdev}:${mmcpart} ${loadaddr} ${bootdir}/${bsp_script};\0" \
+	"bootscript_part=2\0" \
+	"loadbootscript=load mmc ${mmcdev}:${bootscript_part} ${loadaddr} ${bootdir}/${bsp_script};\0" \
 	"bootscript=echo Running bootscript from mmc ...; " \
 		"source\0" \
 	"loadimage=load mmc ${mmcdev}:${mmcpart} ${img_addr} ${bootdir}/${image};" \
@@ -156,20 +157,19 @@
 		"run ramsize_check; " \
 		"mmc dev ${mmcdev}; " \
 		"if mmc rescan; then " \
-			"if test ${use_m7} = yes && run loadm7bin; then " \
-				"run runm7bin; " \
-			"fi; " \
 			"if run loadbootscript; then " \
 				"run bootscript; " \
 			"else "\
+				"echo No bootscript found, booting from mmc...; " \
+			"fi; "\
+			"for part in 3 4 1; do " \
+				"echo trying to boot from partition ${part}...; " \
+				"setenv mmcpart 3; " \
 				"if run loadimage; then " \
 					"run mmcboot; " \
-				"else " \
-					"echo Failed to boot from current MMC ...; " \
 				"fi; " \
-			"fi; " \
-		"else " \
-			"booti ${loadaddr} - ${fdt_addr}; " \
+			"done; " \
+			"echo Failed to boot from any source!; " \
 		"fi;"
 
 /* Link Definitions */

--- a/include/configs/imx8mn_var_som.h
+++ b/include/configs/imx8mn_var_som.h
@@ -152,48 +152,25 @@
 		"else " \
 			"echo wait for boot; " \
 		"fi;\0" \
-	"netargs=setenv bootargs ${mcore_clk} console=${console} " \
-		"root=/dev/nfs ${cma_size} cma_name=linux,cma " \
-		"ip=dhcp nfsroot=${serverip}:${nfsroot},v3,tcp\0" \
-	"netboot=echo Booting from net ...; " \
-		"if test ${ip_dyn} = yes; then " \
-			"setenv get_cmd dhcp; " \
-		"else " \
-			"setenv get_cmd tftp; " \
-		"fi; " \
-		"${get_cmd} ${img_addr} ${image}; unzip ${img_addr} ${loadaddr};" \
-		"run netargs; " \
-		"run optargs; " \
-		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
-			"run findfdt; " \
-			"echo fdt_file=${fdt_file}; " \
-			"if ${get_cmd} ${fdt_addr_r} ${fdt_file}; then " \
-				"booti ${loadaddr} - ${fdt_addr_r}; " \
-			"else " \
-				"echo WARN: Cannot load the DT; " \
-			"fi; " \
-		"else " \
-			"booti; " \
-		"fi;\0" \
 	"bsp_bootcmd=echo Running BSP bootcmd ...; " \
-	"run ramsize_check; " \
-	"mmc dev ${mmcdev}; " \
-	"if mmc rescan; then " \
-		"if test ${use_m7} = yes && run loadm7bin; then " \
-			"run runm7bin; " \
-		"fi; " \
-		"if run loadbootscript; then " \
-			"run bootscript; " \
-		"else "\
-			"if run loadimage; then " \
-				"run mmcboot; " \
-			"else " \
-				"run netboot; " \
+		"run ramsize_check; " \
+		"mmc dev ${mmcdev}; " \
+		"if mmc rescan; then " \
+			"if test ${use_m7} = yes && run loadm7bin; then " \
+				"run runm7bin; " \
 			"fi; " \
-		"fi; " \
-	"else " \
-		"booti ${loadaddr} - ${fdt_addr}; " \
-	"fi;"
+			"if run loadbootscript; then " \
+				"run bootscript; " \
+			"else "\
+				"if run loadimage; then " \
+					"run mmcboot; " \
+				"else " \
+					"echo Failed to boot from current MMC ...; " \
+				"fi; " \
+			"fi; " \
+		"else " \
+			"booti ${loadaddr} - ${fdt_addr}; " \
+		"fi;"
 
 /* Link Definitions */
 


### PR DESCRIPTION
With the upcoming A/B boot we are also introducing a new partition
scheme which in return will no longer boot with the hardcoded mmcpart=1
which is used for the variscite debian boot process.
To be able to recover in case of a broken bootscript we now scan both
root_a and root_b paritions for bootable images as well as the legacy partition
one to keep compatibility with the variscite images.

Signed-off-by: Mimoja <mimoja@meticuloushome.com>